### PR TITLE
Network change events script

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -179,6 +179,11 @@ Provides travel times for UAM trips for a list of origins and destinations and a
 	* coordinate-pairs-file.csv header [format]: origin_x [`double`], origin_y [`double`], destination_x [`double`], destination_y [`double`], trip_time [`HH:MM:SS`]
 	* allowed UAMStrategies: `minTravelTime, minAccessTravelTime, minDistance, minAccessDistance`
 
+### RunGenerateNetworkChangeEventsFile
+Generates a NetworkChangeEvents file containing changes in the network throughout the day. 
+* Location: net.bhl.matsim.uam.analysis.traveltimes.RunGenerateNetworkChangeEventsFile
+* Arguments: `PATH/network.xml(.gz) PATH/events.xml(.gz) PATH/output-networkEventsChange-file.xml(.gz)`
+
 ### ConvertDemographicsFromPopulation
 Creates a demographics file by reading through and gathering socio-demographic attributes from each person object in an existing population (or plan) file.
 * Location: net.bhl.matsim.uam.analysis.demographics.ConvertDemographicsFromPopulation

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ List of all current features provided by MATSim-UAM with the version of feature 
 ### v1.1
 Input/output:
 - UAM-enabled MATSim networks are required to provide an flight attribute indicating every flight links' flight segment (e.g. vertical or horizontal). **No backwards compatibility of input network files.**
+- Included script for generating networkChangeEvents (files) from simulation results
 
 Logging:
 - Limited waiting time and failed UAM routing warnings to ten occurrences

--- a/src/main/java/net/bhl/matsim/uam/analysis/traveltimes/RunGenerateNetworkChangeEventsFile.java
+++ b/src/main/java/net/bhl/matsim/uam/analysis/traveltimes/RunGenerateNetworkChangeEventsFile.java
@@ -62,7 +62,7 @@ public class RunGenerateNetworkChangeEventsFile {
 		new NetworkChangeEventsWriter().write(networkEventsChangeFile, networkChangeEvents);
 	}
 
-	public static TravelTimeCalculator readEventsIntoTravelTimeCalculator(Network network, String eventsFile,
+	private TravelTimeCalculator readEventsIntoTravelTimeCalculator(Network network, String eventsFile,
 			TravelTimeCalculatorConfigGroup group) {
 		EventsManager manager = EventsUtils.createEventsManager();
 		TravelTimeCalculator tcc = TravelTimeCalculator.create(network, group);
@@ -71,7 +71,7 @@ public class RunGenerateNetworkChangeEventsFile {
 		return tcc;
 	}
 
-	public static List<NetworkChangeEvent> createNetworkChangeEvents(Network network, TravelTimeCalculator tcc,
+	private List<NetworkChangeEvent> createNetworkChangeEvents(Network network, TravelTimeCalculator tcc,
 			Double endTime, Double timeStep, Double MinFreeSpeed) {
 		List<NetworkChangeEvent> networkChangeEvents = new ArrayList<>();
 		for (Link l : network.getLinks().values()) {

--- a/src/main/java/net/bhl/matsim/uam/analysis/traveltimes/RunGenerateNetworkChangeEventsFile.java
+++ b/src/main/java/net/bhl/matsim/uam/analysis/traveltimes/RunGenerateNetworkChangeEventsFile.java
@@ -1,0 +1,108 @@
+package net.bhl.matsim.uam.analysis.traveltimes;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.matsim.api.core.v01.network.Link;
+import org.matsim.api.core.v01.network.Network;
+import org.matsim.core.api.experimental.events.EventsManager;
+import org.matsim.core.config.Config;
+import org.matsim.core.config.ConfigUtils;
+import org.matsim.core.config.groups.TravelTimeCalculatorConfigGroup;
+import org.matsim.core.events.EventsUtils;
+import org.matsim.core.events.MatsimEventsReader;
+import org.matsim.core.network.NetworkChangeEvent;
+import org.matsim.core.network.NetworkUtils;
+import org.matsim.core.network.NetworkChangeEvent.ChangeType;
+import org.matsim.core.network.io.MatsimNetworkReader;
+import org.matsim.core.network.io.NetworkChangeEventsWriter;
+import org.matsim.core.trafficmonitoring.TravelTimeCalculator;
+
+/**
+ * This script generates a NetworkChangeEvents file containing changes in the
+ * network throughout the day. Necessary inputs are in the following order:
+ * -Network file; -Events file; -output;
+ *
+ * @author Aitanm (Aitan Militao), RRothfeld (Raoul Rothfeld)
+ */
+
+public class RunGenerateNetworkChangeEventsFile {
+	private double timeStep = 15 * 60; // Time step set to 15 minutes
+	double minFreeSpeed = 3;
+	double endTime = 30 * 60 * 60; // end time set to 30 hours
+
+	public RunGenerateNetworkChangeEventsFile() {
+	}
+
+	public static void main(String[] args) throws Exception {
+		// ARGS
+		int j = 0;
+		String networkInput = args[j++];
+		String eventsFileInput = args[j++];
+		String networkEventsChangeFile = args[j++];
+
+		Config config = ConfigUtils.createConfig();
+		config.network().setInputFile(networkInput);
+
+		RunGenerateNetworkChangeEventsFile fileGenerator = new RunGenerateNetworkChangeEventsFile();
+		fileGenerator.generateNetworkChangeEventsFile(networkInput, eventsFileInput, networkEventsChangeFile, config);
+
+	}
+
+	public void generateNetworkChangeEventsFile(String networkInput, String eventsFileInput,
+			String networkEventsChangeFile, Config config) {
+		// Generate networkChangeEvents file for the Time-Dependent Network
+		Network networkForReader = NetworkUtils.createNetwork();
+		new MatsimNetworkReader(networkForReader).readFile(networkInput);
+		TravelTimeCalculator tcc = readEventsIntoTravelTimeCalculator(networkForReader, eventsFileInput,
+				config.travelTimeCalculator());
+		config.qsim().setEndTime(endTime);
+		List<NetworkChangeEvent> networkChangeEvents = createNetworkChangeEvents(networkForReader, tcc,
+				config.qsim().getEndTime(), timeStep, minFreeSpeed);
+		new NetworkChangeEventsWriter().write(networkEventsChangeFile, networkChangeEvents);
+	}
+
+	public static TravelTimeCalculator readEventsIntoTravelTimeCalculator(Network network, String eventsFile,
+			TravelTimeCalculatorConfigGroup group) {
+		EventsManager manager = EventsUtils.createEventsManager();
+		TravelTimeCalculator tcc = TravelTimeCalculator.create(network, group);
+		manager.addHandler(tcc);
+		new MatsimEventsReader(manager).readFile(eventsFile);
+		return tcc;
+	}
+
+	public static List<NetworkChangeEvent> createNetworkChangeEvents(Network network, TravelTimeCalculator tcc,
+			Double endTime, Double timeStep, Double MinFreeSpeed) {
+		List<NetworkChangeEvent> networkChangeEvents = new ArrayList<>();
+		for (Link l : network.getLinks().values()) {
+
+			//if (l.getId().toString().startsWith("pt")) continue;
+
+			double length = l.getLength();
+			double previousTravelTime = l.getLength() / l.getFreespeed();
+
+			for (double time = 0; time < endTime; time = time + timeStep) {
+
+				double newTravelTime = tcc.getLinkTravelTimes().getLinkTravelTime(l, time, null, null);
+
+				if (newTravelTime != previousTravelTime) {
+					// log.warn("Linkd ID: "+ l.getId()+" previousTravelTime: "+previousTravelTime+"
+					// NewTravelTime: "+ newTravelTime);
+					NetworkChangeEvent nce = new NetworkChangeEvent(time);
+					nce.addLink(l);
+					double newFreespeed = length / newTravelTime;
+					if (newFreespeed < MinFreeSpeed)
+						newFreespeed = MinFreeSpeed;
+					NetworkChangeEvent.ChangeValue freespeedChange = new NetworkChangeEvent.ChangeValue(
+							ChangeType.ABSOLUTE_IN_SI_UNITS, newFreespeed);
+					nce.setFreespeedChange(freespeedChange);
+
+					networkChangeEvents.add(nce);
+					previousTravelTime = newTravelTime;
+				}
+			}
+		}
+		return networkChangeEvents;
+	}
+
+}


### PR DESCRIPTION
Script version to generate the networkChangeEvents file.
Input arguments:
- Network
- Events
- Output networkChangeEvents file

The class can also be instantiated and generate the networkChangeEvents file by using the method `generateNetworkChangeEventsFile`, which uses the same input parameters as if running th script alone plus the Config object.

-Updated the `RunCalculateCarTravelTimes` script to use the new script.
-Added description to the Documentation