### PR TITLE
fix a bug in case access time to uam is zero

### DIFF
--- a/src/main/java/net/bhl/matsim/uam/router/UAMCachedIntermodalRoutingModule.java
+++ b/src/main/java/net/bhl/matsim/uam/router/UAMCachedIntermodalRoutingModule.java
@@ -161,6 +161,8 @@ public class UAMCachedIntermodalRoutingModule implements RoutingModule {
 						network.getLinks().get(fromFacility.getLinkId()), uamRoute.bestOriginStation.getLocationLink(),
 						uamRoute.accessMode, UAMConstants.access + uamRoute.accessMode);
 				currentTime += uavAccessLeg.getTravelTime().seconds();
+				uavAccessLeg.setTravelTime(0.0);
+				uavAccessLeg.getRoute().setTravelTime(0.0);
 				trip.add(uavAccessLeg);
 		}
 


### PR DESCRIPTION
when the uam access time is zero, before the booking can be processed
the agent already switches to the interaction activity. This caused
issues in the booking engine. Now this is handled properly.