### PR TITLE
Milos work

### DIFF
--- a/src/main/java/net/bhl/matsim/uam/qsim/BookingEngine.java
+++ b/src/main/java/net/bhl/matsim/uam/qsim/BookingEngine.java
@@ -111,7 +111,7 @@ public class BookingEngine implements MobsimEngine, PersonDepartureEventHandler,
 				Plan plan = ((PlanAgent) agent).getCurrentPlan();
 				final Integer planElementsIndex = WithinDayAgentUtils.getCurrentPlanElementIndex(agent);
 				final Leg accessLeg = (Leg) plan.getPlanElements().get(planElementsIndex - 1);
-				if (!(Math.abs(accessLeg.getTravelTime().seconds() - 0.0) < 0.0001))
+				if (!(accessLeg.getTravelTime().seconds()  < 1.0))
 					throw new RuntimeException("Person with id " + agent.getId().toString()
 							+ " should be on a leg" + accessLeg.toString() + " but it is not. It is on "
 							+ ((PlanAgent) agent).getCurrentPlanElement().toString());

--- a/src/main/java/net/bhl/matsim/uam/qsim/BookingEngine.java
+++ b/src/main/java/net/bhl/matsim/uam/qsim/BookingEngine.java
@@ -113,7 +113,7 @@ public class BookingEngine implements MobsimEngine, PersonDepartureEventHandler,
 				final Leg accessLeg = (Leg) plan.getPlanElements().get(planElementsIndex - 1);
 				if (!(Math.abs(accessLeg.getTravelTime().seconds() - 0.0) < 0.0001))
 					throw new RuntimeException("Person with id " + agent.getId().toString()
-							+ " should be on a leg but it is not. It is on "
+							+ " should be on a leg" + accessLeg.toString() + " but it is not. It is on "
 							+ ((PlanAgent) agent).getCurrentPlanElement().toString());
 				else {
 					if (accessLeg.getMode().startsWith(UAMConstants.access)) {


### PR DESCRIPTION
Interestingly what is contained in the OptionalTime for the leg travel time can be a double value, which is then converted to a time step value. Therefore, values are rounded.

This is now taken into account in the special cases where access legs are zero seconds long.