### PR TITLE
Release 3.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ This extension enhances MATSim (see the project's [Website](https://www.matsim.o
 Add the following to your maven pom.xml under `repositories`:
 ```xml
         <repository>
-            <id>jitpack.io</id>
-            <url>https://jitpack.io</url>
+            <id>uam</id>
+            <url>https://packagecloud.io/eth-ivt/uam/maven2</url>
         </repository>
 ```
 And the following to you maven pom.xml under `dependencies` for the latest version under active development:
@@ -16,7 +16,7 @@ And the following to you maven pom.xml under `dependencies` for the latest versi
         <dependency>
             <groupId>com.github.BauhausLuftfahrt</groupId>
             <artifactId>MATSim-UAM</artifactId>
-            <version>master-SNAPSHOT</version>
+            <version>3.0.0</version>
         </dependency>
 ```
 Older versions can be used by replacing the version text with any of the listed tags on [GitHub MATSim-UAM tags](https://github.com/BauhausLuftfahrt/MATSim-UAM/tags).

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ Older versions can be used by replacing the version text with any of the listed 
 ## Versions and Change Log
 
 ### Development
+
+### v3.0.0
 General:
 - Update to MATSim v12
 - Removal of ptSimulation config setting

--- a/README.md
+++ b/README.md
@@ -7,19 +7,19 @@ This extension enhances MATSim (see the project's [Website](https://www.matsim.o
 Add the following to your maven pom.xml under `repositories`:
 ```xml
         <repository>
-            <id>uam</id>
+            <id>eth-ivt-uam</id>
             <url>https://packagecloud.io/eth-ivt/uam/maven2</url>
         </repository>
 ```
 And the following to you maven pom.xml under `dependencies` for the latest version under active development:
 ```xml
         <dependency>
-            <groupId>com.github.BauhausLuftfahrt</groupId>
-            <artifactId>MATSim-UAM</artifactId>
+            <groupId>net.bhl.matsim</groupId>
+            <artifactId>matsim-uam</artifactId>
             <version>3.0.0</version>
         </dependency>
 ```
-Older versions can be used by replacing the version text with any of the listed tags on [GitHub MATSim-UAM tags](https://github.com/BauhausLuftfahrt/MATSim-UAM/tags).
+Older versions are currently not supported.
 
 ## Versions and Change Log
 

--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,13 @@
 		<maven.compiler.source>11</maven.compiler.source>
 		<maven.compiler.target>11</maven.compiler.target>
 	</properties>
+	
+	<distributionManagement>
+		<repository>
+			<id>packagecloud-uam</id>
+			<url>packagecloud+https://packagecloud.io/eth-ivt/uam</url>
+		</repository>
+	</distributionManagement>
 
 	<build>
 		<plugins>
@@ -31,6 +38,13 @@
 				</configuration>
 			</plugin>
 		</plugins>
+		<extensions>
+			<extension>
+				<groupId>io.packagecloud.maven.wagon</groupId>
+				<artifactId>maven-packagecloud-wagon</artifactId>
+				<version>0.0.6</version>
+			</extension>
+		</extensions>
 	</build>
 
 	<repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>net.bhl.matsim</groupId>
 	<artifactId>matsim-uam</artifactId>
-	<version>2.1</version>
+	<version>3.0.0</version>
 	<packaging>jar</packaging>
 
 	<properties>


### PR DESCRIPTION
This will:

- make a new release that includes MATSim v12 updates and several patches.
- use packagecloud for releases instead of jitpack

